### PR TITLE
Implement operator< so we can put Guid in std::map

### DIFF
--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -72,6 +72,7 @@ private:
 
 	// make the << operator a friend so it can access _bytes
 	friend std::ostream &operator<<(std::ostream &s, const Guid &guid);
+	friend bool operator<(const Guid &lhs, const Guid &rhs);
 };
 
 Guid newGuid();

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -99,6 +99,11 @@ std::ostream &operator<<(std::ostream &s, const Guid &guid)
 	return s;
 }
 
+bool operator<(const xg::Guid &lhs, const xg::Guid &rhs)
+{
+	return lhs.bytes() <  rhs.bytes();
+}
+
 bool Guid::isValid() const
 {
 	xg::Guid empty;

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -18,6 +18,7 @@ int test(std::ostream &outStream)
 	xg::Guid s2("16d1bd03-09a5-47d3-944b-5e326fd52d27");
 	xg::Guid s3("fdaba646-e07e-49de-9529-4499a5580c75");
 	xg::Guid s4("7bcd757f-5b10-4f9b-af69-1a1f226f3b3e");
+	xg::Guid s5("7bcd757f-5b10-4f9b-af69-1a1f226f3b31");
 
 	if (r1 == r2 || r1 == r3 || r2 == r3)
 	{
@@ -34,6 +35,11 @@ int test(std::ostream &outStream)
 	if (s1 != s4)
 	{
 		outStream << "FAIL - s1 and s4 should be equal" << std::endl;
+		failed++;
+	}
+
+	if (s4 < s5) {
+		outStream << "FAIL - s5 should should less than s4" << std::endl;
 		failed++;
 	}
 


### PR DESCRIPTION
Without this implemented we can't put xg::Guid objects in a map without a comparator.
For example, the following is complete with this addition:
std::map<xg::Guid, std::string> hftOrdersToPGroup;

Some simple coverage is included.