### PR TITLE
String conversion perf improvements + minor unrelated changes

### DIFF
--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -146,7 +146,7 @@ Guid::Guid(std::array<unsigned char, 16> &&bytes) : _bytes(std::move(bytes))
 { }
 
 // converts a single hex char to a number (0 - 15)
-unsigned char hexDigitToChar(char ch)
+static unsigned char hexDigitToChar(char ch)
 {
 	// 0-9
 	if (ch > 47 && ch < 58)
@@ -163,7 +163,7 @@ unsigned char hexDigitToChar(char ch)
 	return 0;
 }
 
-bool isValidHexChar(char ch)
+static bool isValidHexChar(char ch)
 {
 	// 0-9
 	if (ch > 47 && ch < 58)
@@ -181,7 +181,7 @@ bool isValidHexChar(char ch)
 }
 
 // converts the two hexadecimal characters to an unsigned char (a byte)
-unsigned char hexPairToChar(char a, char b)
+static unsigned char hexPairToChar(char a, char b)
 {
 	return hexDigitToChar(a) * 16 + hexDigitToChar(b);
 }

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -113,27 +113,16 @@ bool Guid::isValid() const
 // convert to string using std::snprintf() and std::string
 std::string Guid::str() const
 {
-	char one[10], two[6], three[6], four[6], five[14];
-
-	snprintf(one, 10, "%02x%02x%02x%02x",
-		_bytes[0], _bytes[1], _bytes[2], _bytes[3]);
-	snprintf(two, 6, "%02x%02x",
-		_bytes[4], _bytes[5]);
-	snprintf(three, 6, "%02x%02x",
-		_bytes[6], _bytes[7]);
-	snprintf(four, 6, "%02x%02x",
-		_bytes[8], _bytes[9]);
-	snprintf(five, 14, "%02x%02x%02x%02x%02x%02x",
+	constexpr size_t guidSize = sizeof("01234567-0123-0123-0123-0123456789ab");
+	char out[guidSize];
+	snprintf(out, guidSize, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		_bytes[0], _bytes[1], _bytes[2], _bytes[3],
+		_bytes[4], _bytes[5],
+		_bytes[6], _bytes[7],
+		_bytes[8], _bytes[9],
 		_bytes[10], _bytes[11], _bytes[12], _bytes[13], _bytes[14], _bytes[15]);
-	const std::string sep("-");
-	std::string out(one);
 
-	out += sep + two;
-	out += sep + three;
-	out += sep + four;
-	out += sep + five;
-
-	return out;
+	return std::string(out, guidSize - 1);
 }
 
 // conversion operator for std::string

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -304,7 +304,7 @@ Guid newGuid()
 Guid newGuid()
 {
 	GUID newId;
-	CoCreateGuid(&newId);
+	(void)CoCreateGuid(&newId);
 
 	std::array<unsigned char, 16> bytes =
 	{

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -113,16 +113,16 @@ bool Guid::isValid() const
 // convert to string using std::snprintf() and std::string
 std::string Guid::str() const
 {
-	constexpr size_t guidSize = sizeof("01234567-0123-0123-0123-0123456789ab");
-	char out[guidSize];
-	snprintf(out, guidSize, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	constexpr size_t guidBufferSize = sizeof("01234567-0123-0123-0123-0123456789ab");
+	char buffer[guidBufferSize];
+	snprintf(buffer, guidBufferSize, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
 		_bytes[0], _bytes[1], _bytes[2], _bytes[3],
 		_bytes[4], _bytes[5],
 		_bytes[6], _bytes[7],
 		_bytes[8], _bytes[9],
 		_bytes[10], _bytes[11], _bytes[12], _bytes[13], _bytes[14], _bytes[15]);
 
-	return std::string(out, guidSize - 1);
+	return std::string(buffer, guidBufferSize - 1);
 }
 
 // conversion operator for std::string


### PR DESCRIPTION
The main change here is a rewrite of `Guid::str` to make only one call to `snprintf` and avoid string concatenation entirely. It just puts the bytes directly into a buffer and then copies that into the string. My microbenchmarks showed a 15-20% improvement in string conversion there. While this isn't the most common Guid operation it's a decent saving. And I would argue that the new code is a little more clear anyway.

I also snuck in some minor unrelated changes:
- (Win32-specific) Explicitly discard the result of `CoCreateGuid`. MSDN says this is always `S_OK` but it's still marked `_Check_result_` which can cause a warning if you don't, well, check the result.
- Mark some helper functions static to give them internal linkage