### PR TITLE
Bugfix: Allow to compile with C++17

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ cmake ..
 make install
 ```
 
+The library can also be build with `c++17` by using `-DCMAKE_CXX_STANDARD=17` 
+which enables `std::string_view` support.
+
 ## Running tests
 
 After compiling as described above you should get two files: `libcrossguid.a` (the

--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -49,12 +49,17 @@ BEGIN_XG_NAMESPACE
 class Guid
 {
 public:
+	Guid();
+	
 	explicit Guid(const std::array<unsigned char, 16> &bytes);
 	explicit Guid(std::array<unsigned char, 16> &&bytes);
 
+#if __cplusplus >= 201703L
 	explicit Guid(std::string_view fromString);
-	Guid();
-	
+#else
+	explicit Guid(std::string fromString);
+#endif
+
 	Guid(const Guid &other) = default;
 	Guid &operator=(const Guid &other) = default;
 	Guid(Guid &&other) = default;

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -198,7 +198,11 @@ unsigned char hexPairToChar(char a, char b)
 }
 
 // create a guid from string
+#if __cplusplus >= 201703L
 Guid::Guid(std::string_view fromString)
+#else
+Guid::Guid(std::string fromString)
+#endif
 {
 	char charOne = '\0';
 	char charTwo = '\0';


### PR DESCRIPTION
Could you please merge this, this enables string_view only when compiling with `c++17` support.