### PR TITLE
Make some things constexpr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,27 +27,13 @@ before_install:
         command curl -sSL https://rvm.io/mpapis.asc | gpg --import -;
         rvm get head || true
     fi
-  
+
 script:
   - export CHECKOUT_PATH=`pwd`;
   - echo "ROOT_PATH= $ROOT_PATH"
   - echo "CHECKOUT_PATH= $CHECKOUT_PATH"
-
-  #######################################################################################
-  # Install a recent CMake (unless already installed on OS X)
-  #######################################################################################
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="http://www.cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"
-      mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
-      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-    else
-      brew upgrade cmake || echo "suppress failures in order to ignore warnings"
-      brew link --overwrite cmake
-    fi
   - cmake --version
-
-  - | 
+  - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       sudo apt-get install uuid-dev
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           packages:
             - g++-8
       env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+        - MATRIX_EVAL="export CC=gcc-8 && export CXX=g++-8"
 
     - os: osx
       osx_image: xcode9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-sudo: required
 language: cpp
+os: linux
 dist: trusty
 
-matrix:
+jobs:
   include:
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,13 @@ matrix:
           packages:
             - g++-8
       env:
-        - MATRIX_EVAL="export CC=gcc-8 && export CXX=g++-8"
+        - CC=gcc-8 CXX=g++-8
 
     - os: osx
       osx_image: xcode9.2
       compiler: clang
 
 before_install:
-  # Make sure we set correct env for platform
-  - eval "$(MATRIX_EVAL)"
-
   # Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
   # See https://github.com/searchivarius/nmslib/pull/259
   - |

--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -86,7 +86,7 @@ public:
 	// overload inequality operator
 	constexpr bool operator!=(const Guid &other) const { return !(*this == other); }
 
-	// convert to string using std::snprintf() and std::string
+	// convert to string
 	std::string str() const
 	{
 		std::stringstream stream;

--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -29,12 +29,11 @@ THE SOFTWARE.
 #include <jni.h>
 #endif
 
-#include <iostream>
 #include <array>
+#include <iomanip>
+#include <ostream>
 #include <sstream>
 #include <string_view>
-#include <utility>
-#include <iomanip>
 
 #define BEGIN_XG_NAMESPACE namespace xg {
 #define END_XG_NAMESPACE }

--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -49,35 +49,70 @@ BEGIN_XG_NAMESPACE
 class Guid
 {
 public:
-	explicit Guid(const std::array<unsigned char, 16> &bytes);
-	explicit Guid(std::array<unsigned char, 16> &&bytes);
+	// create a guid from vector of bytes
+	explicit constexpr Guid(const std::array<unsigned char, 16> &bytes)
+		: _bytes{ bytes } {}
+	// create a guid from vector of bytes
+	explicit constexpr Guid(std::array<unsigned char, 16> &&bytes)
+		: _bytes{ std::move(bytes) } {}
 
-	explicit Guid(std::string_view fromString);
-	Guid();
-	
-	Guid(const Guid &other) = default;
-	Guid &operator=(const Guid &other) = default;
-	Guid(Guid &&other) = default;
-	Guid &operator=(Guid &&other) = default;
+	// create a guid from string
+	explicit constexpr Guid(std::string_view fromString);
 
-	bool operator==(const Guid &other) const;
-	bool operator!=(const Guid &other) const;
+	// create empty guid
+	constexpr Guid()
+		: _bytes{ {0} } {}
 
+	constexpr Guid(const Guid &other) = default;
+	constexpr Guid &operator=(const Guid &other) = default;
+	constexpr Guid(Guid &&other) = default;
+	constexpr Guid &operator=(Guid &&other) = default;
+
+	// overload equality operator
+	constexpr bool operator==(const Guid &other) const
+	{
+		// Hopefully the optimizer can be smart about this :))))
+		for (std::size_t i = 0; i < _bytes.size(); i += 1) {
+			if (_bytes[i] != other._bytes[i])
+				return false;
+		}
+		return true;
+	}
+	// overload inequality operator
+	constexpr bool operator!=(const Guid &other) const { return !(*this == other); }
+
+	// convert to string using std::snprintf() and std::string
 	std::string str() const;
-	operator std::string() const;
-	const std::array<unsigned char, 16>& bytes() const;
-	void swap(Guid &other);
-	bool isValid() const;
+	// conversion operator for std::string
+	operator std::string() const { return str(); }
+	// Access underlying bytes
+	constexpr const std::array<unsigned char, 16>& bytes() const { return _bytes; }
+	// member swap function
+	void swap(Guid &other) { _bytes.swap(other._bytes); }
+	constexpr bool isValid() const
+	{
+		Guid empty;
+		return *this != empty;
+	}
 
 private:
-	void zeroify();
+	// set all bytes to zero
+	constexpr void zeroify()
+	{
+		for (std::size_t i = 0; i < _bytes.size(); i += 1) {
+			_bytes[i] = 0;
+		}
+	}
 
 	// actual data
-	std::array<unsigned char, 16> _bytes;
+	std::array<unsigned char, 16> _bytes{ {0} };
 
 	// make the << operator a friend so it can access _bytes
 	friend std::ostream &operator<<(std::ostream &s, const Guid &guid);
-	friend bool operator<(const Guid &lhs, const Guid &rhs);
+	friend bool operator<(const Guid &lhs, const Guid &rhs)
+	{
+		return lhs.bytes() <	rhs.bytes();
+	}
 };
 
 Guid newGuid();
@@ -125,15 +160,91 @@ namespace details
 	};
 }
 
+// converts a single hex char to a number (0 - 15)
+constexpr unsigned char hexDigitToChar(char ch)
+{
+	// 0-9
+	if (ch > 47 && ch < 58)
+		return ch - 48;
+
+	// a-f
+	if (ch > 96 && ch < 103)
+		return ch - 87;
+
+	// A-F
+	if (ch > 64 && ch < 71)
+		return ch - 55;
+
+	return 0;
+}
+
+constexpr bool isValidHexChar(char ch)
+{
+	// 0-9
+	if (ch > 47 && ch < 58)
+		return true;
+
+	// a-f
+	if (ch > 96 && ch < 103)
+		return true;
+
+	// A-F
+	if (ch > 64 && ch < 71)
+		return true;
+
+	return false;
+}
+
+// converts the two hexadecimal characters to an unsigned char (a byte)
+constexpr unsigned char hexPairToChar(char a, char b)
+{
+	return hexDigitToChar(a) * 16 + hexDigitToChar(b);
+}
+
+constexpr Guid::Guid(std::string_view fromString) {
+	char charOne = '\0';
+	char charTwo = '\0';
+	bool lookingForFirstChar = true;
+	unsigned nextByte = 0;
+
+	for (const char &ch : fromString)
+	{
+		if (ch == '-')
+			continue;
+
+		if (nextByte >= 16 || !isValidHexChar(ch))
+		{
+			// Invalid string so bail
+			zeroify();
+			return;
+		}
+
+		if (lookingForFirstChar)
+		{
+			charOne = ch;
+			lookingForFirstChar = false;
+		}
+		else
+		{
+			charTwo = ch;
+			auto byte = hexPairToChar(charOne, charTwo);
+			_bytes[nextByte++] = byte;
+			lookingForFirstChar = true;
+		}
+	}
+
+	// if there were fewer than 16 bytes in the string then guid is bad
+	if (nextByte < 16)
+	{
+		zeroify();
+		return;
+	}
+}
+
 END_XG_NAMESPACE
 
 namespace std
 {
-	// Template specialization for std::swap<Guid>() --
-	// See guid.cpp for the function definition
-	template <>
-	void swap(xg::Guid &guid0, xg::Guid &guid1) noexcept;
-
 	// Specialization for std::hash<Guid> -- this implementation
 	// uses std::hash<std::string> on the stringification of the guid
 	// to calculate the hash

--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include <jni.h>
 #endif
 
-#include <functional>
 #include <iostream>
 #include <array>
 #include <sstream>
@@ -39,6 +38,13 @@ THE SOFTWARE.
 
 #define BEGIN_XG_NAMESPACE namespace xg {
 #define END_XG_NAMESPACE }
+
+// forward decl
+BEGIN_XG_NAMESPACE
+class Guid;
+END_XG_NAMESPACE
+
+inline std::ostream &operator<<(std::ostream &s, const xg::Guid &guid);
 
 BEGIN_XG_NAMESPACE
 
@@ -82,7 +88,12 @@ public:
 	constexpr bool operator!=(const Guid &other) const { return !(*this == other); }
 
 	// convert to string using std::snprintf() and std::string
-	std::string str() const;
+	std::string str() const
+	{
+		std::stringstream stream;
+		stream << *this;
+		return stream.str();
+	}
 	// conversion operator for std::string
 	operator std::string() const { return str(); }
 	// Access underlying bytes
@@ -107,8 +118,6 @@ private:
 	// actual data
 	std::array<unsigned char, 16> _bytes{ {0} };
 
-	// make the << operator a friend so it can access _bytes
-	friend std::ostream &operator<<(std::ostream &s, const Guid &guid);
 	friend bool operator<(const Guid &lhs, const Guid &rhs)
 	{
 		return lhs.bytes() <	rhs.bytes();
@@ -257,4 +266,34 @@ namespace std
 			return xg::details::hash<uint64_t, uint64_t>{}(p[0], p[1]);
 		}
 	};
+}
+
+// overload << so that it's easy to convert to a string
+inline std::ostream &operator<<(std::ostream &s, const xg::Guid &guid)
+{
+	auto& bytes = guid.bytes();
+	std::ios_base::fmtflags f(s.flags()); // politely don't leave the ostream in hex mode
+	s << std::hex << std::setfill('0')
+		<< std::setw(2) << (int)bytes[0]
+		<< std::setw(2) << (int)bytes[1]
+		<< std::setw(2) << (int)bytes[2]
+		<< std::setw(2) << (int)bytes[3]
+		<< "-"
+		<< std::setw(2) << (int)bytes[4]
+		<< std::setw(2) << (int)bytes[5]
+		<< "-"
+		<< std::setw(2) << (int)bytes[6]
+		<< std::setw(2) << (int)bytes[7]
+		<< "-"
+		<< std::setw(2) << (int)bytes[8]
+		<< std::setw(2) << (int)bytes[9]
+		<< "-"
+		<< std::setw(2) << (int)bytes[10]
+		<< std::setw(2) << (int)bytes[11]
+		<< std::setw(2) << (int)bytes[12]
+		<< std::setw(2) << (int)bytes[13]
+		<< std::setw(2) << (int)bytes[14]
+		<< std::setw(2) << (int)bytes[15];
+	s.flags(f);
+	return s;
 }

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <cstring>
 #include "crossguid/guid.hpp"
 
 #ifdef GUID_LIBUUID
@@ -69,61 +68,6 @@ void initJni(JNIEnv *env)
 	androidInfo = AndroidGuidInfo::fromJniEnv(env);
 }
 #endif
-
-// overload << so that it's easy to convert to a string
-std::ostream &operator<<(std::ostream &s, const Guid &guid)
-{
-	std::ios_base::fmtflags f(s.flags()); // politely don't leave the ostream in hex mode
-	s << std::hex << std::setfill('0')
-		<< std::setw(2) << (int)guid._bytes[0]
-		<< std::setw(2) << (int)guid._bytes[1]
-		<< std::setw(2) << (int)guid._bytes[2]
-		<< std::setw(2) << (int)guid._bytes[3]
-		<< "-"
-		<< std::setw(2) << (int)guid._bytes[4]
-		<< std::setw(2) << (int)guid._bytes[5]
-		<< "-"
-		<< std::setw(2) << (int)guid._bytes[6]
-		<< std::setw(2) << (int)guid._bytes[7]
-		<< "-"
-		<< std::setw(2) << (int)guid._bytes[8]
-		<< std::setw(2) << (int)guid._bytes[9]
-		<< "-"
-		<< std::setw(2) << (int)guid._bytes[10]
-		<< std::setw(2) << (int)guid._bytes[11]
-		<< std::setw(2) << (int)guid._bytes[12]
-		<< std::setw(2) << (int)guid._bytes[13]
-		<< std::setw(2) << (int)guid._bytes[14]
-		<< std::setw(2) << (int)guid._bytes[15];
-	s.flags(f);
-	return s;
-}
-
-// convert to string using std::snprintf() and std::string
-std::string Guid::str() const
-{
-	char one[10], two[6], three[6], four[6], five[14];
-
-	snprintf(one, 10, "%02x%02x%02x%02x",
-		_bytes[0], _bytes[1], _bytes[2], _bytes[3]);
-	snprintf(two, 6, "%02x%02x",
-		_bytes[4], _bytes[5]);
-	snprintf(three, 6, "%02x%02x",
-		_bytes[6], _bytes[7]);
-	snprintf(four, 6, "%02x%02x",
-		_bytes[8], _bytes[9]);
-	snprintf(five, 14, "%02x%02x%02x%02x%02x%02x",
-		_bytes[10], _bytes[11], _bytes[12], _bytes[13], _bytes[14], _bytes[15]);
-	const std::string sep("-");
-	std::string out(one);
-
-	out += sep + two;
-	out += sep + three;
-	out += sep + four;
-	out += sep + five;
-
-	return out;
-}
 
 // This is the linux friendly implementation, but it could work on other
 // systems that have libuuid available

--- a/src/guid.cpp
+++ b/src/guid.cpp
@@ -99,17 +99,6 @@ std::ostream &operator<<(std::ostream &s, const Guid &guid)
 	return s;
 }
 
-bool operator<(const xg::Guid &lhs, const xg::Guid &rhs)
-{
-	return lhs.bytes() <  rhs.bytes();
-}
-
-bool Guid::isValid() const
-{
-	xg::Guid empty;
-	return *this != empty;
-}
-
 // convert to string using std::snprintf() and std::string
 std::string Guid::str() const
 {
@@ -134,137 +123,6 @@ std::string Guid::str() const
 	out += sep + five;
 
 	return out;
-}
-
-// conversion operator for std::string
-Guid::operator std::string() const
-{
-	return str();
-}
-
-// Access underlying bytes
-const std::array<unsigned char, 16>& Guid::bytes() const
-{
-    return _bytes;
-}
-
-// create a guid from vector of bytes
-Guid::Guid(const std::array<unsigned char, 16> &bytes) : _bytes(bytes)
-{ }
-
-// create a guid from vector of bytes
-Guid::Guid(std::array<unsigned char, 16> &&bytes) : _bytes(std::move(bytes))
-{ }
-
-// converts a single hex char to a number (0 - 15)
-unsigned char hexDigitToChar(char ch)
-{
-	// 0-9
-	if (ch > 47 && ch < 58)
-		return ch - 48;
-
-	// a-f
-	if (ch > 96 && ch < 103)
-		return ch - 87;
-
-	// A-F
-	if (ch > 64 && ch < 71)
-		return ch - 55;
-
-	return 0;
-}
-
-bool isValidHexChar(char ch)
-{
-	// 0-9
-	if (ch > 47 && ch < 58)
-		return true;
-
-	// a-f
-	if (ch > 96 && ch < 103)
-		return true;
-
-	// A-F
-	if (ch > 64 && ch < 71)
-		return true;
-
-	return false;
-}
-
-// converts the two hexadecimal characters to an unsigned char (a byte)
-unsigned char hexPairToChar(char a, char b)
-{
-	return hexDigitToChar(a) * 16 + hexDigitToChar(b);
-}
-
-// create a guid from string
-Guid::Guid(std::string_view fromString)
-{
-	char charOne = '\0';
-	char charTwo = '\0';
-	bool lookingForFirstChar = true;
-	unsigned nextByte = 0;
-
-	for (const char &ch : fromString)
-	{
-		if (ch == '-')
-			continue;
-
-		if (nextByte >= 16 || !isValidHexChar(ch))
-		{
-			// Invalid string so bail
-			zeroify();
-			return;
-		}
-
-		if (lookingForFirstChar)
-		{
-			charOne = ch;
-			lookingForFirstChar = false;
-		}
-		else
-		{
-			charTwo = ch;
-			auto byte = hexPairToChar(charOne, charTwo);
-			_bytes[nextByte++] = byte;
-			lookingForFirstChar = true;
-		}
-	}
-
-	// if there were fewer than 16 bytes in the string then guid is bad
-	if (nextByte < 16)
-	{
-		zeroify();
-		return;
-	}
-}
-
-// create empty guid
-Guid::Guid() : _bytes{ {0} }
-{ }
-
-// set all bytes to zero
-void Guid::zeroify()
-{
-	std::fill(_bytes.begin(), _bytes.end(), static_cast<unsigned char>(0));
-}
-
-// overload equality operator
-bool Guid::operator==(const Guid &other) const
-{
-	return _bytes == other._bytes;
-}
-
-// overload inequality operator
-bool Guid::operator!=(const Guid &other) const
-{
-	return !((*this) == other);
-}
-
-// member swap function
-void Guid::swap(Guid &other)
-{
-	_bytes.swap(other._bytes);
 }
 
 // This is the linux friendly implementation, but it could work on other
@@ -390,14 +248,3 @@ Guid newGuid()
 
 
 END_XG_NAMESPACE
-
-// Specialization for std::swap<Guid>() --
-// call member swap function of lhs, passing rhs
-namespace std
-{
-	template <>
-	void swap(xg::Guid &lhs, xg::Guid &rhs) noexcept
-	{
-		lhs.swap(rhs);
-	}
-}


### PR DESCRIPTION
This constexpr-ifies just enough things to allow for a constexpr `Guid(std::string_view)` constructor. Now you can write readable GUIDs at compile time:

```cpp
static constexpr auto SomeGuid = xg::Guid("AF465C71-9588-11cf-A020-00AA006157AC");
```

After that, there was barely any code left in the guid.cpp file. I moved the remaining short functions into the header file too. Only `newGuid()` requires that users add the guid.cpp file to their compilation, to avoid pulling things like the windows.h header or a libuuid dependency in the header file. This is kinda just a thing I like but not _necessary_ by any stretch so if you don't prefer it I'm happy to revert that.

Some of the constexpr methods have manually written loops instead of non-constexpr `std::fill` and stuff. `isValid()` and `zeroify()` are both required by the `Guid(std::string_view)` constructor so I had to make do to make that constexpr :)

Also updated CI to work again. The `MATRIX_EVAL` stuff appears to be broken despite Travis recommending it in their docs? Weird. Removed the Homebrew update that was taking ages, Travis must've updated the CMake version on their OSX image at some point because it's now recent enough.