### PR TITLE
include missing <cstdint>

### DIFF
--- a/include/crossguid/guid.hpp
+++ b/include/crossguid/guid.hpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <jni.h>
 #endif
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <array>


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>