### PR TITLE
Fix mismatched library name

### DIFF
--- a/cmake/FindLibuuid.cmake
+++ b/cmake/FindLibuuid.cmake
@@ -15,7 +15,7 @@ find_library(LIBUUID_LIBRARY
 )
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LibUUID
+find_package_handle_standard_args(Libuuid
 	FOUND_VAR
 		LIBUUID_FOUND
 	REQUIRED_VARS


### PR DESCRIPTION
Fixes:

```
[cmake] CMake Warning (dev) at /usr/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
[cmake]   The package name passed to `find_package_handle_standard_args` (LibUUID)
[cmake]   does not match the name of the calling package (Libuuid).  This can lead to
[cmake]   problems in calling code that expects `find_package` result variables
[cmake]   (e.g., `_FOUND`) to follow a certain pattern.
[cmake] Call Stack (most recent call first):
[cmake]   /app/build/_deps/crossguid-src/cmake/FindLibuuid.cmake:18 (find_package_handle_standard_args)
[cmake]   /app/build/_deps/crossguid-src/CMakeLists.txt:33 (find_package)
```